### PR TITLE
Open drawer available

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,3 +483,8 @@ await BluetoothEscposPrinter.printerAlign(BluetoothEscposPrinter.ALIGN.CENTER);
 await  BluetoothEscposPrinter.printText("欢迎下次光临\n\r\n\r\n\r",{});
 await BluetoothEscposPrinter.printerAlign(BluetoothEscposPrinter.ALIGN.LEFT);
 ```
+
+### Demo for opening the drawer ###
+```javascript
+BluetoothEscposPrinter.opendDrawer(0, 250, 250);
+```

--- a/android/src/main/java/cn/jystudio/bluetooth/escpos/RNBluetoothEscposPrinterModule.java
+++ b/android/src/main/java/cn/jystudio/bluetooth/escpos/RNBluetoothEscposPrinterModule.java
@@ -341,7 +341,7 @@ public class RNBluetoothEscposPrinterModule extends ReactContextBaseJavaModule
              * Returns: byte[]
              */
             byte[] data = PrintPicture.POS_PrintBMP(mBitmap, width, nMode, leftPadding);
-            //	SendDataByte(buffer);
+            //  SendDataByte(buffer);
             sendDataByte(Command.ESC_Init);
             sendDataByte(Command.LF);
             sendDataByte(data);
@@ -444,6 +444,18 @@ public class RNBluetoothEscposPrinterModule extends ReactContextBaseJavaModule
             Log.d(TAG, e.getMessage());
         }
     }
+
+
+    @ReactMethod
+    public void cutOnePoint() {
+        try{
+            byte[] command = PrinterCommand.POS_Cut_One_Point();
+            sendDataByte(command);
+
+         }catch (Exception e){
+            Log.d(TAG, e.getMessage());
+        }
+    }    
 
     private boolean sendDataByte(byte[] data) {
         if (data==null || mService.getState() != BluetoothService.STATE_CONNECTED) {

--- a/android/src/main/java/cn/jystudio/bluetooth/escpos/RNBluetoothEscposPrinterModule.java
+++ b/android/src/main/java/cn/jystudio/bluetooth/escpos/RNBluetoothEscposPrinterModule.java
@@ -434,6 +434,17 @@ public class RNBluetoothEscposPrinterModule extends ReactContextBaseJavaModule
         sendDataByte(command);
     }
 
+    @ReactMethod
+    public void openDrawer(int nMode, int nTime1, int nTime2) {
+        try{
+            byte[] command = PrinterCommand.POS_Set_Cashbox(nMode, nTime1, nTime2);
+            sendDataByte(command);
+
+         }catch (Exception e){
+            Log.d(TAG, e.getMessage());
+        }
+    }
+
     private boolean sendDataByte(byte[] data) {
         if (data==null || mService.getState() != BluetoothService.STATE_CONNECTED) {
             return false;

--- a/android/src/main/java/cn/jystudio/bluetooth/escpos/command/sdk/Command.java
+++ b/android/src/main/java/cn/jystudio/bluetooth/escpos/command/sdk/Command.java
@@ -125,7 +125,7 @@ public class Command {
 	public static byte[] DLE_DC4 = new byte[] {DLE, DC4, 0x00, 0x00, 0x00 };
 	
 	//标准弹钱箱指令
-	public static byte[] ESC_p = new byte[] {ESC, 'F', 0x00, 0x00, 0x00 };
+	public static byte[] ESC_p = new byte[] {ESC, 'p', 0x00, 0x00, 0x00 };
 	
 	/**
 	 * 条码设置指令

--- a/android/src/main/java/cn/jystudio/bluetooth/escpos/command/sdk/PrinterCommand.java
+++ b/android/src/main/java/cn/jystudio/bluetooth/escpos/command/sdk/PrinterCommand.java
@@ -346,6 +346,16 @@ public class PrinterCommand {
 
     }
 
+    /**
+     * 
+     *
+     * 
+     * @return
+     */
+    public static byte[] POS_Cut_One_Point() {
+        return Command.GS_i;
+    }    
+
 //***********************************以下函数为公开函数***********************************************************//
 
     /**


### PR DESCRIPTION
Added the method openDrawer visible to react, in order to open the drawer with the byte sequence of each printer. 

Example for Epson printers. Bytes array => {ESC, 'p', 0x00, 0x00, 0x00 }