### PR TITLE
Corrects bug found in DPP250 printer

### DIFF
--- a/android/src/main/java/cn/jystudio/bluetooth/escpos/command/sdk/PrinterCommand.java
+++ b/android/src/main/java/cn/jystudio/bluetooth/escpos/command/sdk/PrinterCommand.java
@@ -239,11 +239,8 @@ public class PrinterCommand {
         byte[] escM = Arrays.copyOf(Command.ESC_M, Command.ESC_M.length);
         escM[2] = (byte) nFontType;
         byte[] data = null;
-        if (codepage == 0) {
-            data = concatAll(gsExclamationMark, escT, Command.FS_and, escM, pbString);
-        } else {
-            data = concatAll(gsExclamationMark, escT, Command.FS_dot, escM, pbString);
-        }
+        data = concatAll(gsExclamationMark, escT, escM, pbString);
+        
         return data;
     }
 


### PR DESCRIPTION
After this change, the DPP250 printer does not print '.' or '&' in the beggining of each line. This code was tested in DPP250 and LEOPARDO A8 printer and in both of them this code worked