### PR TITLE
Bugfix: BT Scan not working for API 29

### DIFF
--- a/android/src/main/java/cn/jystudio/bluetooth/RNBluetoothManagerModule.java
+++ b/android/src/main/java/cn/jystudio/bluetooth/RNBluetoothManagerModule.java
@@ -175,11 +175,11 @@ public class RNBluetoothManagerModule extends ReactContextBaseJavaModule
             promise.reject(EVENT_BLUETOOTH_NOT_SUPPORT);
         }else {
             cancelDisCovery();
-            int permissionChecked = ContextCompat.checkSelfPermission(reactContext, android.Manifest.permission.ACCESS_COARSE_LOCATION);
+            int permissionChecked = ContextCompat.checkSelfPermission(reactContext, android.Manifest.permission.ACCESS_FINE_LOCATION);
             if (permissionChecked == PackageManager.PERMISSION_DENIED) {
                 // // TODO: 2018/9/21
                 ActivityCompat.requestPermissions(reactContext.getCurrentActivity(),
-                        new String[]{android.Manifest.permission.ACCESS_COARSE_LOCATION},
+                        new String[]{android.Manifest.permission.ACCESS_FINE_LOCATION},
                         1);
             }
 


### PR DESCRIPTION
Bluetooth Scan is no longer working if an app uses `API 29` as `compileSdkVersion`. Fix is to ask for `ACCESS_FINE_LOCATION` instead of `ACCESS_COARSE_LOCATION`. 

https://developer.android.com/about/versions/10/privacy/changes#location-telephony-bluetooth-wifi