### PR TITLE
resolve artifacts for configuration :classpath

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
     repositories {
+        google()
         jcenter { url "http://jcenter.bintray.com/" }
         maven {url "http://repo.spring.io/plugins-release/"}
         mavenCentral()


### PR DESCRIPTION
Problems:
- always getting this error whenever run ```react-native run-android```
![Screen Shot 2022-05-23 at 16 51 59](https://user-images.githubusercontent.com/74668899/169793584-212ac519-f2f0-46cd-8cae-f9523377b7c3.png)
s


currently I've added those ```google()``` line inside my node_modules in my react-native project. 


but it's seems temporary, so I made this pull request.